### PR TITLE
Error on switch language on multiple locale site

### DIFF
--- a/Croogo/Controller/CroogoAppController.php
+++ b/Croogo/Controller/CroogoAppController.php
@@ -270,7 +270,9 @@ class CroogoAppController extends Controller {
 			}
 		}
 
-		if (isset($this->request->params['locale'])) {
+		// we should add Configure::write('localeLanguages', array('fra', 'eng', 'ara')); on Config/croogo.php
+		if (isset($this->request->params['locale']) && in_array($this->request->params['locale'], Configure::read('localeLanguages')))
+		{
 			Configure::write('Config.language', $this->request->params['locale']);
 		}
 


### PR DESCRIPTION
I have a website with a multiple languages (eng, fra, ara), sometimes when i click on the link to switch for example from **ara** to **eng**, it dose not work !!! the website redirect to the source language and the current language become **img** - when i check `Configure::read('Config.language')` it show **img** . it work in some pages and not on others, after trying and checking, i found that the problem is caused by **broken images**, and it's not work just in the pages having a broken images, because broken images give errors like 

```
2015-11-12 00:28:37 Error: [MissingControllerException] Controller class ClientsController could not be found.
Exception Attributes: array (
  'class' => 'ClientsController',
  'plugin' => NULL,
)
Request URL: /laboratory/img/clients/centre-city.jpg
```

and it take the **img** as a language's alias, that is why when i check `Configure::read('Config.language')` it contain **img**

 also when i check **beforeFilter** at **Croogo/Croogo/Controller/CroogoAppController**, i found that `Configure::read('Config.language')` take **img** as a langague's alias, it can access even there is no locale on the url.

```
		if (isset($this->request->params['locale'])) {
			Configure::write('Config.language', $this->request->params['locale']);
		}
```

### Solution
So that is why we should check if the current language was defined by the user or not, 

```
		// we should add Configure::write('localeLanguages', array('fra', 'eng', 'ara')); on Config/croogo.php
		if (isset($this->request->params['locale']) && in_array($this->request->params['locale'], Configure::read('localeLanguages')))
		{
			Configure::write('Config.language', $this->request->params['locale']);
		}
```

and it work fine like that.