### PR TITLE
Thumbnail is not showing in admin_browse

### DIFF
--- a/FileManager/View/Attachments/admin_browse.ctp
+++ b/FileManager/View/Attachments/admin_browse.ctp
@@ -41,9 +41,9 @@
 				'editor' => 1,
 			), array('icon' => $this->Theme->getIcon('delete'), 'tooltip' => __d('croogo', 'Delete')), __d('croogo', 'Are you sure?'));
 
-			$mimeType = explode('/', $attachment['Attachment']['mime_type']);
-			$mimeType = $mimeType['0'];
-			$imageType = $mimeType[1];
+			$mime_type = explode('/', $attachment['Attachment']['mime_type']);
+			$mimeType = $mime_type[0];
+			$imageType = $mime_type[1];
 			$imagecreatefrom = array('gif', 'jpeg', 'png', 'string', 'wbmp', 'webp', 'xbm', 'xpm');
 			if ($mimeType == 'image' && in_array($imageType, $imagecreatefrom)) {
 				$thumbnail = $this->Html->link($this->Image->resize($attachment['Attachment']['path'], 100, 200), $attachment['Attachment']['path'], array(


### PR DESCRIPTION
When we upload image using attachmenet, the thumbnail is not showing in admin_browse, because the $mimeType['1'] var is overwrite by $mimeType['0'] and the condition if become false.
and these work for me.
			$mime_type = explode('/', $attachment['Attachment']['mime_type']);
			$mimeType = $mime_type[0];
			$imageType = $mime_type[1];